### PR TITLE
Shared Repos, https://github.com/OctoShelf/octoshelf/issues/7

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ With OctoShelf you can...
 * Check for new pull requests (Managed by a background web worker)
 * Receive notifications when tabbed away (using Notifications API)
 * Point API calls to an enterprise account (see below)
+* Share a group of repos with someone else
+    * Example: `http://www.octoshelf.com/?share=facebook/react,polymer/polymer`
 
 ## Running the App
 

--- a/index.js
+++ b/index.js
@@ -43,9 +43,11 @@ function getAccessToken(req) {
 }
 
 app.get('/', function (req, res) {
+  let query = req.query || {};
+  let sharedRepos = query.share || '';
   let origin = req.protocol + '://' + req.get('host');
   let accessToken = getAccessToken(req);
-  let data = Object.assign({}, config, {origin, accessToken});
+  let data = Object.assign({}, config, {origin, accessToken, sharedRepos});
   res.render('index.ejs', data);
 });
 

--- a/public/scripts/octo.worker.js
+++ b/public/scripts/octo.worker.js
@@ -86,7 +86,7 @@ function addRepo(url) {
   url = url.replace(/\/+$/, '');
 
   if (repositories.find(repo => repo.url === url)) {
-    parsedPostMessage('notify', 'That repo was already added');
+    parsedPostMessage('notify', `"${url}" was already added`);
     return;
   }
 

--- a/public/scripts/octoshelf.js
+++ b/public/scripts/octoshelf.js
@@ -16,6 +16,8 @@ function OctoShelf(options) {
   const initApiUrl = options.initApiUrl || 'https://api.github.com';
   const initGithubUrl = options.initGithubUrl || 'https://github.com/';
   const origin = options.origin || 'http://www.octoshelf.com';
+  const sharedReposString = options.sharedRepos || '';
+  const sharedRepos = sharedReposString.split(',');
 
   const appWorker = new Worker('./scripts/octo.worker.js');
   const app = document.getElementById('octoshelf');
@@ -32,6 +34,10 @@ function OctoShelf(options) {
 
   const toggleViewType = document.getElementById('toggleViewType');
   const moreInfoToggle = document.getElementById('moreInfoToggle');
+
+  const shareWrapper = document.getElementById('shareWrapper');
+  const shareContent = document.getElementById('shareContent');
+  const shareToggle = document.getElementById('shareToggle');
 
   const stylesheetHelper = document.createElement("style");
   const topPanelHeight = 60;
@@ -157,6 +163,18 @@ function OctoShelf(options) {
     toggleViewType.addEventListener('click', function(event) {
       event.preventDefault();
       app.classList.toggle('octoInline');
+    });
+    shareToggle.addEventListener('click', function(event) {
+      event.preventDefault();
+      let child = repoSection.firstChild;
+      let urls = [];
+      while (child) {
+        urls.push(child.dataset.url);
+        child = child.nextSibling;
+      }
+      let url = window.location.origin + '?share=' + urls.join(',');
+      shareWrapper.classList.toggle('toggle');
+      shareContent.innerText = url;
     });
 
     window.addEventListener('resize', function() {
@@ -646,6 +664,16 @@ function OctoShelf(options) {
   }
 
   /**
+   * If the url has the share queryParam, pass in each of the repos.
+   * Example url: /?share=org/repo1,org/repo2,org/repo3
+   */
+  function loadSharedRepos() {
+    sharedRepos.filter(repo => repo).forEach(url => {
+      addRepository(url);
+    });
+  }
+
+  /**
    * Initialize the app!
    */
   (function init() {
@@ -662,6 +690,7 @@ function OctoShelf(options) {
     updateBubbleStyles(window.innerHeight, window.innerWidth);
     resizeGitubPrefix();
     repoStateManager.fetch();
+    loadSharedRepos();
     startRefreshing(startingRefreshRate);
     loadEventListeners();
   })();

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -70,6 +70,21 @@ a{ color: #fff}
 .action {vertical-align: text-top;margin: 5px}
 .action:hover {text-shadow: 0 0 10px #fff}
 
+.share-wrapper {}
+.share-content {
+    background: #fff;
+    color: #333;
+    display: none;
+    position: absolute;
+    right: 0;
+    bottom: 3rem;
+    font-size: 0.5rem;
+    padding: 1rem;
+}
+.share-wrapper.toggle .share-content {
+    display: block;
+}
+
 /* Magical overrides */
 .prList.lotsOfPRs .prListItem {height: 15px;width: 15px;margin: 1px;}
 .prList.lotsOfPRs .prLink {font-size: 0.5em;padding:0;top: -3px}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -97,6 +97,10 @@
                 <div class="notification-moreInfo">Allow Notifications?</div>
             </span>
             <a href="#" id="toggleViewType" class="octicon octicon-three-bars toggleViewType"></a>
+            <span id="shareWrapper" class="share-wrapper">
+                <a href="#" id="shareToggle" class="octicon octicon-link share-toggle"></a>
+                <span id="shareContent" class="share-content"></span>
+            </span>
             <a href="#" id="moreInfoToggle" class="octicon octicon-question moreInfo-toggle"></a>
         </span>
     </section>
@@ -147,6 +151,7 @@
         initAccessToken: '<%= accessToken %>',
         initApiUrl: '<%= apiUrl %>',
         initGithubUrl: '<%= githubUrl %>',
+        sharedRepos: '<%= sharedRepos %>',
         origin: '<%= origin %>'
     });
 </script>


### PR DESCRIPTION
This commit adds a new feature, sharable repos.

Given the following url structure, you can share a link with
multiple repos for the user to add:

```
/?share=MyOrg1/repo1,MyOrg1/repo2,MyOrg2/repo1
```

I've also included a link button inside the top panel.