### PR TITLE
Minor CSS Fix for Safari on Mobile

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -324,7 +324,7 @@ a{ color: #fff}
     border-radius: 0;
     padding: 1rem;
 }
-.octoInline .bubble .repositoryInner {transform: none !important;}
+.octoInline .bubble .repositoryInner {transform: none !important;height: initial;}
 .octoInline .repo-title {margin-right: 1rem;width: inherit;}
 .octoInline .repository:after {display: none;}
 .octoInline + .infoPanel {margin-top: 0rem;}


### PR DESCRIPTION
The pull request section on safari looked super-flat.  This PR is
just adds an inherit height so that it doesn't look broken.

## Before
<img width="718" alt="screen shot 2016-06-11 at 9 26 25 am" src="https://cloud.githubusercontent.com/assets/364028/15986450/266ef62c-2fbd-11e6-9119-112875345a82.png">

## After
<img width="719" alt="screen shot 2016-06-11 at 9 25 44 am" src="https://cloud.githubusercontent.com/assets/364028/15986455/2fcece86-2fbd-11e6-9f0e-af8e83301db9.png">

