### PR TITLE
Making the "About OctoShelf" section opt-in only

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ app.use(webpackDevMiddleware(compiler, {
 const github_client_id = process.env.GITHUB_CLIENT_ID || '';
 const github_client_secret = process.env.GITHUB_CLIENT_SECRET || '';
 const personal_access_token = process.env.PERSONAL_ACCESS_TOKEN || '';
+const showAppDescription = process.env.SHOW_APP_DESCRIPTION || false;
 
 const tokenPayload = {
   "client_id": github_client_id,
@@ -83,6 +84,7 @@ app.get('/', function (req, res) {
   let data = Object.assign({}, config, {
     origin: origin,
     accessToken: accessToken,
+    showAppDescription: showAppDescription,
     sharedRepos: sharedRepos
   });
   res.render('index.ejs', data);

--- a/public/scripts/octoshelf.js
+++ b/public/scripts/octoshelf.js
@@ -155,15 +155,17 @@ export default function OctoShelf(appElement, options, appWorker) {
       event.preventDefault();
       requestNotifications();
     });
-    moreInfoToggle.addEventListener('click', function(event) {
-      event.preventDefault();
-      let height = window.innerHeight - window.scrollY - topPanelHeight;
-      for (let i = 0; i < height; i++) {
-        setTimeout(() => {
-          window.scrollBy(0, 1);
-        }, i);
-      }
-    });
+    if (moreInfoToggle) {
+      moreInfoToggle.addEventListener('click', function(event) {
+        event.preventDefault();
+        let height = window.innerHeight - window.scrollY - topPanelHeight;
+        for (let i = 0; i < height; i++) {
+          setTimeout(() => {
+            window.scrollBy(0, 1);
+          }, i);
+        }
+      });
+    }
     toggleViewType.addEventListener('click', function(event) {
       event.preventDefault();
       appElement.classList.toggle('octoInline');

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -204,14 +204,13 @@ a{ color: #fff}
     background: #333;
     border-top:1px solid #ccc;
     color:#fff;
-    min-height: 100%;
     width:100%;
-    padding: 1rem;
+    padding: 0 1rem;
     position: relative;
     margin-top: -60px;
     text-align: left;
 }
-.infoPanel-topPanel {min-height: 3rem;}
+.infoPanel-topPanel {padding: 1rem 0;}
 .infoPanel .octicon {vertical-align: middle}
 .infoPanel-actions {border-left: 1px solid #fff;padding-left: 0.5rem;margin-left: 0.5rem;position: relative}
 .infoPanel-action {font-size: 1.2em;margin-left: 1rem;}
@@ -250,7 +249,8 @@ a{ color: #fff}
 }
 .infoPanel-description {text-align: center;}
 .infoPanel-description a {color: #333;}
-.infoPanel-exampleCode {
+.infoPanel-exampleCode,
+.infoPanel-exampleCode-noHeader {
     border: 1px solid #ccc;
     background: #fff;
     padding: 1rem 0;
@@ -259,7 +259,10 @@ a{ color: #fff}
 .infoPanel-exampleCode-header {
     margin: 0 1rem;
 }
-.highlight {background: rgba(255,255,0,0.5);padding: 0.5rem}
+.infoPanel-exampleCode-noHeader {
+    padding: 2rem 0 1rem;
+}
+.highlight {background: rgba(255,255,0,0.5);padding: 0.5rem;display: inline-block}
 .octoshelf-transparent {
     background: url('/images/octoshelf-link.png') #333 no-repeat;
     background-size: 75px;
@@ -281,13 +284,13 @@ a{ color: #fff}
 .refreshRate_moreInfo {
     background: #fff;
     color: #333;
-    width: 200px;
+    width: 300px;
     height: 0;
     padding: 0;
     overflow: hidden;
     position: absolute;
     bottom: 3rem;
-    left: 0;
+    right: 0;
     transition: all .5s ease;
 }
 .refreshRate_moreInfo.toggle {height: 120px;padding: 0.5rem;border: 1px solid #333;}
@@ -327,6 +330,7 @@ a{ color: #fff}
 }
 
 @media (max-width: 550px) {
+    .infoPanel {margin-top: 0}
     .tagline {display: none}
 }
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -67,7 +67,9 @@
             <a href="#" class="octicon octicon-broadcast infoPanel-action notification-button" id="requestNotifications"></a>
             <a href="#" id="toggleViewType" class="octicon octicon-three-bars infoPanel-action toggleViewType"></a>
             <a href="#" id="shareToggle" class="octicon octicon-link infoPanel-action share-toggle"></a>
-            <a href="#" id="moreInfoToggle" class="octicon octicon-question infoPanel-action moreInfo-toggle"></a>
+            <% if (showAppDescription) { %>
+                <a href="#" id="moreInfoToggle" class="octicon octicon-question infoPanel-action moreInfo-toggle"></a>
+            <% } %>
             <span class="toggleContentContainer">
                 <span id="refreshContent" class="refreshRate_moreInfo">
                     <div>Refresh Rate</div>
@@ -99,46 +101,9 @@
             </span>
         </span>
     </section>
-    <section id="infoPanelDescription" class="infoPanel-description">
-        <h2>Welcome to OctoShelf!</h2>
-        <p>OctoShelf is here to help you manage pull requests across multiple repositories.</p>
-        <p>OctoShelf is powered by <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">LocalStorage</a>,
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API">WebWorkers</a>,
-            <a href="https://developer.mozilla.org/en-US/docs/Web/API/notification">Notifications</a>,
-            and <a href="https://developer.github.com/v3/">Github's Api</a>.</p>
-
-        <a class="octoshelf-transparent" href="https://github.com/OctoShelf/octoshelf"></a>
-    </section>
-    <section class="infoPanel-example">
-        <h2>Enterprise Usage</h2>
-        <p>If you want to use OctoShelf for public Github, you're in the right place!</p>
-        <p>But, lets say you want this on an enterprise account. All you need to do is fork this repo, and make two changes.</p>
-        <ol class="infoPanel-steps">
-            <li>
-                Update config to point to your enterprise endpoints
-    <pre class="infoPanel-exampleCode">
-    <h3 class="infoPanel-exampleCode-header">/config/githubApi.json</h3>
-    {
-      "githubAuthUrl":  "", // request github access url (redirects back to /auth)
-      "githubTokenUrl": "", // retrieves access_token (called from /auth?code=xxx)
-      "apiUrl":         "", // root github api urls
-      "githubUrl":      ""  // root github repository urls
-    }
-    </pre>
-            </li>
-            <li>
-                Start the app with a public access token or a clientId and clientSecret
-    <pre class="infoPanel-exampleCode">
-    <h3 class="infoPanel-exampleCode-header">Starting the App</h3>
-    <span class="highlight">PERSONAL_ACCESS_TOKEN</span>=xxx npm start
-
-     - or -
-
-    <span class="highlight">GITHUB_CLIENT_ID</span>=xxx <span class="highlight">GITHUB_CLIENT_SECRET</span>=xxx npm start
-    </pre>
-            </li>
-        </ol>
-    </section>
+    <% if (showAppDescription) { %>
+        <% include partials/appDescription %>
+    <% } %>
 </section>
 <script>
     var hydratedConfig = {

--- a/views/partials/appDescription.ejs
+++ b/views/partials/appDescription.ejs
@@ -1,0 +1,46 @@
+<section id="infoPanelDescription" class="infoPanel-description">
+    <h2>Welcome to OctoShelf!</h2>
+    <p>OctoShelf is here to help you manage pull requests across multiple repositories.</p>
+    <p>OctoShelf is powered by <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage">LocalStorage</a>,
+        <a href="https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API">WebWorkers</a>,
+        <a href="https://developer.mozilla.org/en-US/docs/Web/API/notification">Notifications</a>,
+        and <a href="https://developer.github.com/v3/">Github's Api</a>.</p>
+
+    <a class="octoshelf-transparent" href="https://github.com/OctoShelf/octoshelf"></a>
+</section>
+<section class="infoPanel-example">
+    <h2>Enterprise Usage</h2>
+    <p>If you want to use OctoShelf for public Github, you're in the right place!</p>
+    <p>But, lets say you want this on an enterprise account. All you need to do is fork this repo, and make two changes.</p>
+    <ol class="infoPanel-steps">
+        <li>
+            Update config to point to your enterprise endpoints
+    <pre class="infoPanel-exampleCode">
+    <h3 class="infoPanel-exampleCode-header">/config/githubApi.json</h3>
+    {
+      "githubAuthUrl":  "", // request github access url (redirects back to /auth)
+      "githubTokenUrl": "", // retrieves access_token (called from /auth?code=xxx)
+      "apiUrl":         "", // root github api urls
+      "githubUrl":      ""  // root github repository urls
+    }
+    </pre>
+        </li>
+        <li>
+            Start the app with a public access token or a clientId and clientSecret
+    <pre class="infoPanel-exampleCode">
+    <h3 class="infoPanel-exampleCode-header">Starting the App</h3>
+    <span class="highlight">PERSONAL_ACCESS_TOKEN</span>=xxx npm start
+
+     - or -
+
+    <span class="highlight">GITHUB_CLIENT_ID</span>=xxx <span class="highlight">GITHUB_CLIENT_SECRET</span>=xxx npm start
+    </pre>
+        </li>
+    </ol>
+
+    By default, you won't see this usage guide. But, if you want to include it, you could start the app with:
+
+    <pre class="infoPanel-exampleCode-noHeader">
+    <span class="highlight">SHOW_APP_DESCRIPTION=true</span> npm start
+    </pre>
+</section>


### PR DESCRIPTION
One thing that bothered me was baking in all the "about OctoShelf"
section into anyone that wanted to fork it.  People that fork this
webapp shouldn't have to render a usage guide.

So I am making the appDescription area partial that is rendered
by opt-in only.

To render it, you would pass in the environment variable `SHOW_APP_DESCRIPTION`

i.e

```
SHOW_APP_DESCRIPTION=true npm start
```

Otherwise, `showAppDescription` is assumed to be false.

I'm including a screenshot of the new experience (note the lack of
continued scroll bar).


![octoshelf_no_description_section](https://cloud.githubusercontent.com/assets/364028/15992660/15aa0aec-3086-11e6-900d-b410dcd9e96e.jpg)
