### PR TITLE
Splitting up `octoshelf.js` to smaller files

### DIFF
--- a/public/scripts/actionPanel.js
+++ b/public/scripts/actionPanel.js
@@ -1,0 +1,106 @@
+/**
+ * Action Panel is in charge of handling the event listeners and functions
+ * pertaining to the ActionPanel (found on the button of the page).
+ *
+ * ActionPanel actions include
+ *  changing refresh options
+ *  requesting notification permissions
+ *  changing page layout
+ *  toggling sharing the current repos
+ */
+
+const repoSection = document.getElementById('repoSection');
+const requestNotifications = document.getElementById('requestNotifications');
+const refreshRateToggle = document.getElementById('refreshRateToggle');
+const refreshContent = document.getElementById('refreshContent');
+const refreshRateOptions = document.getElementById('refreshRateOptions');
+const shareContent = document.getElementById('shareContent');
+const shareUrl = document.getElementById('shareUrl');
+const shareToggle = document.getElementById('shareToggle');
+const toggleViewType = document.getElementById('toggleViewType');
+const moreInfoToggle = document.getElementById('moreInfoToggle');
+
+const topPanelHeight = 60;
+const startingRefreshRate = 60000;
+
+/**
+ * Request Notification Privileges from the end user
+ */
+function requestNotificationPermission() {
+  Notification.requestPermission();
+}
+
+/**
+ * Load the App event listeners
+ * @param {Element} appElement - The main OctoShelf element
+ * @param {Function} parsedPostMessage - helper postMessage-to-worker function
+ */
+export function loadActionPanelListeners(appElement, parsedPostMessage) {
+  refreshRateOptions.addEventListener('change', function(event) {
+    let {value} = event.target;
+    let delay = Number(value);
+    if (delay) {
+      return parsedPostMessage('startRefreshing', delay);
+    }
+    return parsedPostMessage('stopRefreshing', '');
+  });
+  requestNotifications.addEventListener('click', function(event) {
+    event.preventDefault();
+    requestNotificationPermission();
+  });
+  if (moreInfoToggle) {
+    moreInfoToggle.addEventListener('click', function(event) {
+      event.preventDefault();
+      let height = window.innerHeight - window.scrollY - topPanelHeight;
+      for (let i = 0; i < height; i++) {
+        setTimeout(() => {
+          window.scrollBy(0, 1);
+        }, i);
+      }
+    });
+  }
+  toggleViewType.addEventListener('click', function(event) {
+    event.preventDefault();
+    appElement.classList.toggle('octoInline');
+  });
+  refreshRateToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    shareContent.classList.remove('toggle');
+    refreshContent.classList.toggle('toggle');
+  });
+  shareToggle.addEventListener('click', function(event) {
+    event.preventDefault();
+    updateShareLink();
+    refreshContent.classList.remove('toggle');
+    shareContent.classList.toggle('toggle');
+  });
+
+  parsedPostMessage('startRefreshing', startingRefreshRate);
+}
+
+/**
+ * Subtle UI indication that a refresh has happened
+ */
+export function hasRefreshed() {
+  refreshRateToggle.classList.add('hasRefreshed');
+  setTimeout(() => {
+    refreshRateToggle.classList.remove('hasRefreshed');
+  }, 500);
+}
+
+/**
+ * Update the sharable link (on add/remove of repos, as well as on toggle)
+ */
+export function updateShareLink() {
+  let child = repoSection.firstChild;
+  let urls = [];
+  while (child) {
+    urls.push(child.dataset.url);
+    child = child.nextSibling;
+  }
+  let url = window.location.origin;
+  if (urls.length) {
+    url += '?share=' + urls.join(',');
+  }
+  shareUrl.value = url;
+}

--- a/public/scripts/animations.js
+++ b/public/scripts/animations.js
@@ -1,0 +1,141 @@
+/**
+ * Animations - Animations are in charge of... animating, things. These functions
+ * are generally self-contained and don't have any impact on the app state.
+ */
+
+const stylesheetHelper = document.createElement("style");
+const appBackground = document.getElementById('appBackground');
+const repoSection = document.getElementById('repoSection');
+
+const inputWrapperSize = 130;
+const bubbleSize = 150;
+let centerDistance = 0;
+
+/**
+ * Update Bubble Styles by injecting new css rules
+ * @param {Element} appElement - core OctoShelf app element
+ */
+function updateBubbleStyles(appElement) {
+  let {innerHeight, innerWidth} = window;
+  let modifiedHeight = innerHeight - 40;
+  let bubbleModify = bubbleSize / 2;
+  let top = (innerHeight / 2) - bubbleModify - 40;
+  let left = (innerWidth / 2) - bubbleModify;
+
+  let hDistance = (modifiedHeight / 2) - (bubbleSize * 2 / 3);
+  let wDistance = (innerWidth / 2) - (bubbleSize * 2 / 3);
+  centerDistance = hDistance < wDistance ? hDistance : wDistance;
+
+  while (stylesheetHelper.sheet.cssRules.length) {
+    if (stylesheetHelper.sheet.removeRule) {
+      stylesheetHelper.sheet.removeRule(0);
+    } else if (stylesheetHelper.sheet.deleteRule) {
+      stylesheetHelper.sheet.deleteRule(0);
+    }
+  }
+  let size = bubbleSize;
+  let dims = ['height', 'width'].map(prop => prop + `:${size}px`).join(';');
+  let pos = `top:${top}px;left:${left}px;`;
+  let wrapSelector = '.app-prompt, .app-repositoriesWrapper';
+  let wrapRule = `transition: all .5s ease;${pos};${dims}`;
+
+  let afterHeight = centerDistance - (bubbleSize / 2);
+  let afterRule = `top: ${size}px;height:${afterHeight}px`;
+
+  stylesheetHelper.sheet.insertRule(`${wrapSelector} {${wrapRule}}`, 0);
+  stylesheetHelper.sheet.insertRule(`.bubble {${dims}}`, 0);
+  stylesheetHelper.sheet.insertRule(`.repository:after {${afterRule}}`, 0);
+
+  let toggleInline = innerHeight < 550 || innerWidth < 500;
+  appElement.classList.toggle('octoInline', toggleInline);
+
+  updateRotations();
+}
+
+/**
+ * Github's Prefix is dynamic. To account for corp github urls,
+ * when the page loads we auto resize the font-size to make sure it fits
+ */
+function resizeGitubPrefix() {
+  let prefix = document.querySelector('.addRepoInput-prefix');
+  let prefixWidth = prefix.scrollWidth;
+  let sizeRatio = ~~((inputWrapperSize / (prefixWidth + 10)) * 100) / 100;
+  let fontSize = sizeRatio < 1 ? sizeRatio : 1;
+  prefix.style.fontSize = `${fontSize}rem`;
+}
+
+/**
+ * Lazy Load a sweet background image into focus.
+ *
+ * We start off with a low-res blurred image on the `body` tag that gets loaded
+ * very quickly. We then load a high-res background image to an empty `img` tag.
+ * Once the image has finished loading, we insert the image as a background to
+ * an empty div that has blur(10px), and slowly animate away that blur to 0.
+ */
+function lazyLoadBackground() {
+  let img = document.createElement('img');
+  let imgSrc = '/images/background.jpg';
+  let now = Date.now();
+  img.setAttribute('src', imgSrc);
+
+  img.onload = function() {
+    appBackground.style.backgroundImage = `url(${imgSrc})`;
+    let loadTime = Date.now() - now;
+
+    /**
+     * If the loadTime is less than 100ms, the background was likely cached.
+     * Slowly unbluring the background is a cool nice animation, but if they've
+     * seen it once before, we should limit the duration of the blurry state.
+     */
+    if (loadTime < 1000) {
+      return appBackground.classList.add('loaded');
+    }
+
+    setTimeout(() => {
+      appBackground.classList.add('loaded');
+    }, 1000);
+  };
+}
+
+/**
+ * Update the rotation of the different repo bubbles
+ */
+export function updateRotations() {
+  let count = repoSection.childElementCount;
+  let rotation = 360 / count;
+  let current = 0;
+
+  let child = repoSection.firstElementChild;
+  while (child) {
+    let rotateBy = current * rotation;
+    let transform = `rotate(${rotateBy}deg) translateY(-${centerDistance}px)`;
+    let innerTransform = `transform: rotate(-${rotateBy}deg);`;
+
+    child.style.cssText = `transform: ${transform};`;
+    child.firstElementChild.style.cssText = innerTransform;
+    current++;
+    child = child.nextElementSibling;
+  }
+}
+
+/**
+ * Load initial animations and any animation specific event handlers
+ * @param {Element} appElement - core OctoShelf element
+ */
+export function loadAnimations(appElement) {
+  document.head.appendChild(stylesheetHelper);
+  lazyLoadBackground();
+  updateBubbleStyles(appElement);
+  resizeGitubPrefix();
+
+  let resizeDebounce;
+  window.addEventListener('resize', function() {
+    if (resizeDebounce) {
+      clearTimeout(resizeDebounce);
+    }
+
+    resizeDebounce = setTimeout(() => {
+      updateBubbleStyles(appElement);
+    }, 30);
+  });
+}

--- a/public/scripts/utiltities.js
+++ b/public/scripts/utiltities.js
@@ -23,3 +23,25 @@ export function log() {
     console.log(message);
   }
 }
+
+/**
+ * Notify the user something happened
+ * @param {String} notifyText - Text we want displayed
+ * @param {Number} duration - duration that the notification will linger
+ */
+export function notify(notifyText, duration = 1000) {
+  let notifications = document.getElementById('notifications');
+  let notification = document.createElement('div');
+  notification.setAttribute('class', 'notification');
+
+  notifications
+    .appendChild(notification)
+    .appendChild(document.createTextNode(notifyText));
+
+  setTimeout(function() {
+    notification.classList.add('fadeOut');
+    setTimeout(function() {
+      notifications.removeChild(notification);
+    }, 500);
+  }, duration);
+}

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -210,7 +210,7 @@ a{ color: #fff}
     margin-top: -60px;
     text-align: left;
 }
-.infoPanel-topPanel {padding: 1rem 0;}
+.infoPanel-actionPanel {padding: 1rem 0;}
 .infoPanel .octicon {vertical-align: middle}
 .infoPanel-actions {border-left: 1px solid #fff;padding-left: 0.5rem;margin-left: 0.5rem;position: relative}
 .infoPanel-action {font-size: 1.2em;margin-left: 1rem;}

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -56,7 +56,7 @@
     <section id="appBackground" class="app-background"></section>
 </main>
 <section class="infoPanel">
-    <section class="infoPanel-topPanel">
+    <section class="infoPanel-actionPanel">
         <h1>OctoShelf</h1><span class="tagline">, <span class="tagline-githubPowered">a
             <a href="https://github.com" class="octicon octicon-logo-github"></a>
             powered</span> pull request manager


### PR DESCRIPTION
My plan is to start writing tests on octoshelf.js. However, the
logic for the core app experience (managing repos and prs) is
mingled with the animations and event handlers.

Because of how tied together everything is, it makes it harder to
write tests.

So I pulled out anything animation related into its own file, and
anything having to do with the actionPanel in a separate file.

I'm planning on writing more tests shortly, this is just prep.