### PR TITLE
Decouple the Web Worker from the rest of the app

### DIFF
--- a/public/entry/app.js
+++ b/public/entry/app.js
@@ -2,8 +2,10 @@
 import OctoShelf from '../scripts/octoshelf.js';
 import config from '../../config/config.json';
 
+import {registerWorker} from '../scripts/conductor.js';
+
 const OctoWorker = require("../scripts/octo.worker.js");
-const appWorker = new OctoWorker();
+registerWorker(new OctoWorker());
 
 const serverConfig = hydratedConfig || {};
 const initConfig = Object.assign({}, config, serverConfig);
@@ -11,4 +13,4 @@ const initConfig = Object.assign({}, config, serverConfig);
 const appElement = document.getElementById('octoshelf');
 
 // Execute an OctoShelf and we now have a webapp
-OctoShelf(appElement, initConfig, appWorker);
+OctoShelf(appElement, initConfig);

--- a/public/scripts/actionPanel.js
+++ b/public/scripts/actionPanel.js
@@ -9,6 +9,9 @@
  *  toggling sharing the current repos
  */
 
+import {workerPostMessage, registerWorkerEventHandles} from './conductor';
+const postMessageToWorker = workerPostMessage('ActionPanel');
+
 const repoSection = document.getElementById('repoSection');
 const requestNotifications = document.getElementById('requestNotifications');
 const refreshRateToggle = document.getElementById('refreshRateToggle');
@@ -35,14 +38,14 @@ function requestNotificationPermission() {
  * @param {Element} appElement - The main OctoShelf element
  * @param {Function} parsedPostMessage - helper postMessage-to-worker function
  */
-export function loadActionPanelListeners(appElement, parsedPostMessage) {
+export function loadActionPanelListeners(appElement) {
   refreshRateOptions.addEventListener('change', function(event) {
     let {value} = event.target;
     let delay = Number(value);
     if (delay) {
-      return parsedPostMessage('startRefreshing', delay);
+      return postMessageToWorker('startRefreshing', delay);
     }
-    return parsedPostMessage('stopRefreshing', '');
+    return postMessageToWorker('stopRefreshing', '');
   });
   requestNotifications.addEventListener('click', function(event) {
     event.preventDefault();
@@ -75,7 +78,7 @@ export function loadActionPanelListeners(appElement, parsedPostMessage) {
     shareContent.classList.toggle('toggle');
   });
 
-  parsedPostMessage('startRefreshing', startingRefreshRate);
+  postMessageToWorker('startRefreshing', startingRefreshRate);
 }
 
 /**
@@ -104,3 +107,5 @@ export function updateShareLink() {
   }
   shareUrl.value = url;
 }
+
+registerWorkerEventHandles('ActionPanel', {hasRefreshed});

--- a/public/scripts/conductor.js
+++ b/public/scripts/conductor.js
@@ -1,0 +1,99 @@
+/**
+ * Conductor - He conducts traffic to and from the web worker.
+ *
+ * Conductor acts as a web worker mediator. Its purpose is to decouple modules
+ * from postMessaging and listening to the web worker directly.
+ *
+ * Instead of connecting OctoShelf.js with the Web Worker directly
+ * (forcing function calls to pass through OctoShelf.js), we can
+ * register eventHandlers using `registerWorkerEventHandles`.
+ *
+ * Instead of passing around the web worker to execute postMessages,
+ * we can call `workerPostMessage(source)`, which returns a postMessage
+ * function for us. (bonus, we track the originating source of the postMessage)
+ *
+ * Example Usages:
+ *
+ * import {registerWorkerEventHandles, workerPostMessage} from './conductor';
+ *
+ * let postMessageToWorker = workerPostMessage('TestUtility');
+ *
+ * // Send a message to the worker
+ * postMessageToWorker('workerFn', [1,2,3])
+ *
+ * // Register events from the worker
+ * registerWorkerEventHandles('TestUtility', {assert, log, should});
+ *
+ */
+
+import {log} from './utiltities';
+
+const registeredFns = {};
+const nameMap = {};
+let appWorker;
+
+/**
+ * Send a Parsed Post Message to the web worker
+ * @param {String} fnName - function we will attempt to call
+ * @param {*} postData - Some data that we will wrap into a stringified object
+ */
+function postMessageToWorker(fnName, postData) {
+  if (!(appWorker && appWorker.postMessage)) {
+    log('Web Worker has not been registered');
+    return;
+  }
+  appWorker.postMessage([fnName, JSON.stringify({postData})]);
+}
+
+/**
+ * Execute function mapped to worker's post message
+ * @param {Function} fn - function to call
+ * @param {Function} fnName - function name
+ * @param {String} params - Stringified object that contains a postData prop
+ */
+function executeWorkerEventHandle(fn, fnName, params) {
+  let parsedParams = JSON.parse(params);
+  let {postData} = parsedParams;
+  if (fnName !== 'log') {
+    log(`[Worker] -> [${nameMap[fnName]}] "${fnName}" called with:`, postData);
+  }
+  fn(postData);
+}
+
+/**
+ * Register a worker for posting messages to (and listening for post messages from)
+ * @param {Worker} worker - our web worker
+ */
+export function registerWorker(worker) {
+  appWorker = worker;
+  appWorker.addEventListener('message', function({data: [fnName, fnData]}) {
+    if (registeredFns[fnName]) {
+      return executeWorkerEventHandle(registeredFns[fnName], fnName, fnData);
+    }
+    log(`"${fnName}" was not part of the allowed postMessage functions`);
+  });
+}
+
+/**
+ * Register a series of functions mapped to a handler
+ * @param {String} handlerName - Owner of the event Handler (for logging)
+ * @param {Object} newFns - object of functions
+ */
+export function registerWorkerEventHandles(handlerName, newFns) {
+  Object.assign(registeredFns, newFns);
+  Object.keys(newFns).forEach(fnName => {
+    nameMap[fnName] = handlerName;
+  });
+}
+
+/**
+ * High order function that returns a postMessage function
+ * @param {String} source - postMessage source (for logging)
+ * @return {Function} postMessage function
+ */
+export function workerPostMessage(source) {
+  return (fnName, postData) => {
+    log(`[${source}] -> [Worker] "${fnName}" called with:`, postData);
+    postMessageToWorker(fnName, postData);
+  };
+}

--- a/public/scripts/octo.worker.js
+++ b/public/scripts/octo.worker.js
@@ -31,8 +31,7 @@ const repository = {
  * Its refreshing :D!
  */
 function refreshFn() {
-  log(`Refreshing at ${new Date()}`);
-  parsedPostMessage('hasRefreshed', '');
+  parsedPostMessage('hasRefreshed', `${new Date()}`);
   getAllRepoDetails();
 }
 // the new is unnecessary, but linting gets mad
@@ -290,14 +289,12 @@ function getRepoDetailsByUrl(url) {
 /**
  * Unwrap PostMessages
  * @param {Function} fn - function to call
- * @param {Function} msgType - function name
  * @param {String} params - Stringified object that contains a postData prop
  * @return {Function} - whatever function we executed
  */
-function unwrapPostMessage(fn, msgType, params) {
+function unwrapPostMessage(fn, params) {
   let parsedParams = JSON.parse(params);
-  let postData = parsedParams.postData;
-  log(`[Worker] "${msgType}" called with:`, postData);
+  let {postData} = parsedParams;
   return fn(postData);
 }
 
@@ -388,7 +385,7 @@ function getAPIVariables() {
  * @param {String} msgData - what data is being passed to that worker
  * @return {Function} the executed function
  */
-function postMessageHandler({data: [msgType, msgData]}) {
+function postMessageHandler({data: [fnName, msgData]}) {
   let msgTypes = {
     startRefreshing,
     stopRefreshing,
@@ -402,10 +399,10 @@ function postMessageHandler({data: [msgType, msgData]}) {
     addRepo
   };
 
-  if (msgTypes[msgType]) {
-    return unwrapPostMessage(msgTypes[msgType], msgType, msgData);
+  if (msgTypes[fnName]) {
+    return unwrapPostMessage(msgTypes[fnName], msgData);
   }
-  log(`"${msgType}" isn't part of the allowed functions`);
+  log(`"${fnName}" isn't part of the allowed functions`);
 }
 
 self.addEventListener('message', postMessageHandler);

--- a/public/scripts/utiltities.js
+++ b/public/scripts/utiltities.js
@@ -1,4 +1,6 @@
 
+import {registerWorkerEventHandles} from './conductor';
+
 /**
  * Log a message to console (if console exists)
  * @param {String} message - message to log (or group)
@@ -45,3 +47,6 @@ export function notify(notifyText, duration = 1000) {
     }, 500);
   }, duration);
 }
+
+//
+registerWorkerEventHandles('Utility', {log, notify});


### PR DESCRIPTION
Previously, there was an eventListener on `octoshelf.js`, and a
helper function called `parsedPostMessage`.

If the web worker posted a message, it would always go through the
eventListener found on  `octoshelf.js`, and from `octoshelf.js`,
it might call a function that was `imported` from some other module.
This fundamentally bugged me, because `octoshelf` should not be
responsible for passing functions around.

Additionally, if we wanted to `postMessage` to the web worker, I
created a helper function, `parsedPostMessage`.  Because our
modules were kind of tightly coupled, if they needed to post a message
over, they would either need to be passed the web worker itself,
or we would need to pass the `parsedPostMessage` (since it stored
a reference to the web worker.) This too, kind of sucked, since
we were making functions more tightly coupled than they should have
been.

Now, we have `Conductor`. Conductor is the traffic cordinator between
events going out the web worker, as well as events coming in.

`Conductor` handles outgoing messages by providing a high order
function that performs a postMessage. It handles inbound messages
by having a single eventListener that calls functions that have been
registered with `registerWorkerEventHandles`.

---

I will be honest, I don't know if this is really the best abstraction.

But, I like taking away unnecessary responsibility from `octoshelf.js`,
and it feels nice to not have to pass around the web worker just to
occaisionally add listeners or do postMessages.

This feels like a good approach, but I also know that by separating
things out this way, tracking the call stack of events can get confusing.
Hopefully the generous logging can help, but time will tell if this
was a good split.

For reference, logging looks like:

```
[Thing] -> [Worker] "workerFn" called with:
  params

[Worker] -> [Thing] "thingFn" called with:
  params
```