### PR TITLE
Excluded animations.js from the unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint public/scripts/",
     "coverage": "nyc --reporter=html ava tests/",
     "report": "nyc report",
-    "check-coverage": "nyc check-coverage --lines 20 --functions 20 --branches 10",
+    "check-coverage": "nyc check-coverage --lines 40 --functions 36 --branches 11",
     "test": "npm run coverage; npm run report; npm run check-coverage"
   },
   "pre-commit": [
@@ -59,7 +59,8 @@
   },
   "nyc": {
     "exclude": [
-      "tests"
+      "tests",
+      "**/animations.js"
     ]
   }
 }

--- a/public/scripts/animations.js
+++ b/public/scripts/animations.js
@@ -1,6 +1,8 @@
 /**
  * Animations - Animations are in charge of... animating, things. These functions
  * are generally self-contained and don't have any impact on the app state.
+ *
+ * These functions only provide visual feedback, so excluded from unit tests.
  */
 
 const stylesheetHelper = document.createElement("style");

--- a/public/scripts/octoshelf.js
+++ b/public/scripts/octoshelf.js
@@ -375,19 +375,17 @@ function loadSharedRepos() {
 /**
  * OctoShelf, a Multi-Repo PR Manager
  *
- * If you call OctoShelf without any of these defined, the app will still work.
- * But, without an access_token you will be limited to 60 calls per hour, and
- * if you are intending to access an enterprise github's api, you will need to
- * use a public access token generated from your corp's settings.
- *
  * @param {Object} options - OctoShelf options
+ *
+ * If you call OctoShelf without any options defined, the app will still work,
+ * it will simply use public github api urls as its defaults.
  */
 export default function OctoShelf(options) {
-  accessToken = options.initAccessToken || accessToken;
-  apiUrl = options.initApiUrl || apiUrl;
-  githubUrl = options.initGithubUrl || githubUrl;
-  origin = options.initOrigin || origin;
-  sharedReposString = options.initSharedRepos || sharedReposString;
+  accessToken = options.accessToken || accessToken;
+  apiUrl = options.apiUrl || apiUrl;
+  githubUrl = options.githubUrl || githubUrl;
+  origin = options.origin || origin;
+  sharedReposString = options.sharedRepos || sharedReposString;
   sharedRepos = sharedReposString.split(',');
 
   /**

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -107,9 +107,9 @@
 </section>
 <script>
     var hydratedConfig = {
-        initAccessToken: '<%= accessToken %>',
-        initSharedRepos: '<%= sharedRepos %>',
-        initOrigin: '<%= origin %>'
+        accessToken: '<%= accessToken %>',
+        sharedRepos: '<%= sharedRepos %>',
+        origin: '<%= origin %>'
     }
 </script>
 <script src="/app.js"></script>


### PR DESCRIPTION
`animations.js` only impacted visual... "stuff". It isn't really
*that* testable, so as a result, I am excluding it from nyc coverage.

I also renamed instances of `initApiVars` to `apiVars`, which is a
lot cleaner and less confusing.